### PR TITLE
fix case where input_function is a normal function

### DIFF
--- a/functions/_natural_selection.fish
+++ b/functions/_natural_selection.fish
@@ -30,12 +30,24 @@ function _natural_selection --description 'Input wrapper to improve selection'
     not string match --quiet '*-clipboard' $input_function
   end
 
+  function _is_normal_function --no-scope-shadowing
+    functions --query $input_function
+  end
+
   function _is_cut_input_function --no-scope-shadowing
     string match --quiet 'cut-*' $input_function
   end
 
   function _is_single_character_input_function --no-scope-shadowing
     string match --quiet '*-char' $input_function
+  end
+
+  function _call_input_function --no-scope-shadowing
+    if _is_normal_function
+      $input_function
+    else
+      commandline --function $input_function
+    end
   end
 
   # If not cleared here, then logic further down will cause the cursor to get stuck. It would be nicer if we could do
@@ -53,10 +65,10 @@ function _natural_selection --description 'Input wrapper to improve selection'
     _natural_selection_end_selection
   else if test -n "$_flag_is_selecting"
     _natural_selection_begin_selection
-    commandline --function $input_function
+    _call_input_function
   else if not _natural_selection_is_selecting; and _is_native_input_function
     # Pass through. Keep this high for performance
-    commandline --function $input_function
+    _call_input_function
   else if string match --quiet 'paste-from-clipboard' $input_function
     _natural_selection_replace_selection -- (pbpaste)
   else if _natural_selection_is_selecting
@@ -74,7 +86,7 @@ function _natural_selection --description 'Input wrapper to improve selection'
       _natural_selection_end_selection
 
       if not _is_single_character_input_function
-        commandline --function $input_function
+        _call_input_function
       end
 
       # Ensure that commandline reflects selection

--- a/readme.md
+++ b/readme.md
@@ -39,6 +39,8 @@ set --local characters (string split '' "$letters$numbers$special$pairs")
 
 # Use fish_key_reader to find out bindings. These are a combination of escape sequences and hex codes.
 # The following should already be sent by your terminal:
+set --local up                  \e'[A'
+set --local down                \e'[B'
 set --local left                \e'[C'
 set --local right               \e'[D'
 set --local shift_left          \e'[1;2D'
@@ -63,6 +65,8 @@ set --local command_x           \e'[O'
 set --local command_v           \e'[L'
 
 if functions --query _natural_selection
+  bind $up                  '_natural_selection up-or-search'
+  bind $down                '_natural_selection down-or-search'
   bind $left                '_natural_selection forward-char'
   bind $right               '_natural_selection backward-char'
   bind $shift_left          '_natural_selection backward-char --is-selecting'

--- a/readme.md
+++ b/readme.md
@@ -41,8 +41,8 @@ set --local characters (string split '' "$letters$numbers$special$pairs")
 # The following should already be sent by your terminal:
 set --local up                  \e'[A'
 set --local down                \e'[B'
-set --local left                \e'[C'
-set --local right               \e'[D'
+set --local left                \e'[D'
+set --local right               \e'[C'
 set --local shift_left          \e'[1;2D'
 set --local shift_right         \e'[1;2C'
 set --local backspace           \x7f
@@ -67,8 +67,8 @@ set --local command_v           \e'[L'
 if functions --query _natural_selection
   bind $up                  '_natural_selection up-or-search'
   bind $down                '_natural_selection down-or-search'
-  bind $left                '_natural_selection forward-char'
-  bind $right               '_natural_selection backward-char'
+  bind $left                '_natural_selection backward-char'
+  bind $right               '_natural_selection forward-char'
   bind $shift_left          '_natural_selection backward-char --is-selecting'
   bind $shift_right         '_natural_selection forward-char --is-selecting'
   bind $command_left        '_natural_selection beginning-of-line'


### PR DESCRIPTION
Fixes #6 

Some potential input functions, such as `up-or-search` are "normal" functions (see [here](https://fishshell.com/docs/current/cmds/bind.html#additional-functions)). I added a check to see if the passed input_function is a normal function, if it is it calls it directly, otherwise the input_function is passed along to `commandline --function`.