### PR TITLE
Add support for pressing escape to end selection. Also fix cursor swapping

### DIFF
--- a/functions/_natural_selection.fish
+++ b/functions/_natural_selection.fish
@@ -11,10 +11,12 @@ function _natural_selection --description 'Input wrapper to improve selection'
   function _should_swap_cursor --no-scope-shadowing
     set --local cursor_position (commandline --cursor)
     switch $input_function
-      case 'forward-char' 'end-*'
+      case 'forward-char' 'end-of-*'
         test "$cursor_position" -lt $_natural_selection_selection_start
-      case 'backward-char' 'beginning-*'
+      case 'backward-char' 'beginning-of-*'
         test "$cursor_position" -gt $_natural_selection_selection_start
+      case '*'
+        false
     end
   end
 

--- a/readme.md
+++ b/readme.md
@@ -39,6 +39,7 @@ set --local characters (string split '' "$letters$numbers$special$pairs")
 
 # Use fish_key_reader to find out bindings. These are a combination of escape sequences and hex codes.
 # The following should already be sent by your terminal:
+set --local escape              \e
 set --local up                  \e'[A'
 set --local down                \e'[B'
 set --local left                \e'[D'
@@ -65,6 +66,7 @@ set --local command_x           \e'[O'
 set --local command_v           \e'[L'
 
 if functions --query _natural_selection
+  bind $escape              '_natural_selection end-selection'
   bind $up                  '_natural_selection up-or-search'
   bind $down                '_natural_selection down-or-search'
   bind $left                '_natural_selection backward-char'


### PR DESCRIPTION
This PR does two things:
1. Added support for creating a bind like `bind $escape '_natural_selection end-selection'`. This already mostly worked, except that the cursor would be incorrectly swapped because the check in `_should_swap_cursor` incorrectly matched `end-selection`. Changed that pattern to `end-of-*` to fix this.
2. Added a default case to `_should_swap_cursor` to return false. This fixes an issue where pressing something like `Opt+Left/Right` during a selection wouldn't move the cursor as expected. 