### PR TITLE
Add support for select all with `Cmd+a`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -33,6 +33,7 @@ The following will depend on your terminal as most of these key bindings are not
 # Use fish_key_reader to find out bindings. These are a combination of escape sequences and hex codes.
 # The following should already be sent by your terminal:
 set --local escape              \e
+set --local control_r           \cR
 set --local up                  \e'[A'
 set --local down                \e'[B'
 set --local left                \e'[D'
@@ -57,9 +58,13 @@ set --local option_delete       \ed
 set --local command_c           \e'[Q'
 set --local command_x           \e'[O'
 set --local command_v           \e'[L'
+set --local command_a           \e'[97;9u'
+set --local command_z           \e'[122;9u'
+set --local command_shift_z     \e'[122;10u'
 
 if functions --query _natural_selection
   bind $escape              '_natural_selection end-selection'
+  bind $control_r           '_natural_selection history-pager'
   bind $up                  '_natural_selection up-or-search'
   bind $down                '_natural_selection down-or-search'
   bind $left                '_natural_selection backward-char'
@@ -83,6 +88,9 @@ if functions --query _natural_selection
   bind $command_c           '_natural_selection copy-to-clipboard'
   bind $command_x           '_natural_selection cut-to-clipboard'
   bind $command_v           '_natural_selection paste-from-clipboard'
+  bind $command_a           '_natural_selection select-all'
+  bind $command_z           '_natural_selection undo'
+  bind $command_shift_z     '_natural_selection redo'
   bind ''                   kill-selection end-selection self-insert
 end
 ```


### PR DESCRIPTION
Got one more for you. I appreciate you taking the time to look at these PRs.

- Added support for selecting all text with a keybind (`Cmd+a`).
  - This is done via a "custom" bind function called `select-all` (just like e.g. copy-to-clipboard).
  - Would prefer to just use native fish functions but we can't for reasons you mentioned [here](https://github.com/daleeidd/natural-selection/issues/5#issuecomment-1584459311).
- Also added binds to the readme for `Cmd+z`/`Cmd+shift+z` for undo/redo.
- Added `Ctrl+r` to readme (handle selection for history-pager).

I also spent some time cleaning up the logic for the "main" block of code that handles the bind. I think it's more readable now and makes it more clear exactly what cases we want to catch/handle. This also allowed me to cleanup/remove the `_is_clipboard_input_function`, `_is_native_input_function`, and `_is_cut_input_function` functions.

I've been using this branch pretty extensively for the past couple of weeks and haven't found any issues or performance impacts.